### PR TITLE
added two keybindings for totalcmd:

### DIFF
--- a/apps/totalcmd.hotkeys
+++ b/apps/totalcmd.hotkeys
@@ -30,3 +30,7 @@ v::Return
 ^r::Send {F3}
 ^t::Send ^%t%
 ^/::Send ^\
+; goto parent directory (eq cd ..)
+^@::Send {BackSpace}
+; goto previous directory in history
+^z::Send !{Left}


### PR DESCRIPTION
Ctrl+@ -- goto parent directory
Ctrl+z -- goto previos directory in history

But maybe it's better to use
Ctrl+/ -- Goto parent directory
Ctrl+@ -- Goto root directory
